### PR TITLE
Update Go to 1.21

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [ '1.19' ]
+        go-version: [ '1.19', '1.21' ]
         os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/mdm-code/termcols
 
-go 1.19
+go 1.21


### PR DESCRIPTION
It's time to bump up the Go version for the package.