### PR TITLE
Color text only when the Stdout FD indicates the Terminal

### DIFF
--- a/cmd/tcols/main.go
+++ b/cmd/tcols/main.go
@@ -235,6 +235,9 @@ func open(fnames []string, f func(string) (*os.File, error)) ([]io.Reader, func(
 	return files, closer, nil
 }
 
+// Pipe transfers the input text colorized according to the provided styles
+// from the r reader to the w writer. The colorize parameter controls if the
+// text should be colorized.
 func pipe(r io.Reader, w io.Writer, styles []string, colorize bool) error {
 	if r == nil && w == nil {
 		return errPiping

--- a/cmd/tcols/main.go
+++ b/cmd/tcols/main.go
@@ -41,6 +41,7 @@ import (
 	"sync"
 
 	"github.com/mdm-code/termcols"
+	"golang.org/x/term"
 )
 
 const (
@@ -270,7 +271,10 @@ func run(args []string, fn openFn) error {
 
 	out := newConcurrentWriter(os.Stdout)
 
-	colorize := true
+	var colorize bool
+	if term.IsTerminal(int(os.Stdout.Fd())) {
+		colorize = true
+	}
 
 	var wg sync.WaitGroup
 	wg.Add(len(files))

--- a/cmd/tcols/main_test.go
+++ b/cmd/tcols/main_test.go
@@ -86,19 +86,21 @@ func TestCliParse(t *testing.T) {
 // TestPipeText tests a single, single-threaded pass of text data.
 func TestPipeText(t *testing.T) {
 	cases := []struct {
-		r   io.Reader
-		w   io.Writer
-		s   []string
-		err error
+		reader   io.Reader
+		writer   io.Writer
+		styles   []string
+		colorize bool
+		err      error
 	}{
-		{&mockReader{}, &mockWriter{}, []string{}, nil},
-		{nil, nil, []string{}, errPiping},
-		{&mockReader{}, &mockWriter{}, []string{"blue"}, termcols.ErrMap},
-		{&failReader{}, &mockWriter{}, []string{}, errPiping},
-		{&mockReader{}, &failWriter{}, []string{}, errPiping},
+		{&mockReader{}, &mockWriter{}, []string{}, true, nil},
+		{nil, nil, []string{}, true, errPiping},
+		{&mockReader{}, &mockWriter{}, []string{"blue"}, true, termcols.ErrMap},
+		{&mockReader{}, &mockWriter{}, []string{"red"}, false, termcols.ErrMap},
+		{&failReader{}, &mockWriter{}, []string{}, true, errPiping},
+		{&mockReader{}, &failWriter{}, []string{}, true, errPiping},
 	}
 	for _, c := range cases {
-		err := pipe(c.r, c.w, c.s)
+		err := pipe(c.reader, c.writer, c.styles, c.colorize)
 		if !errors.Is(err, c.err) {
 			t.Errorf("Have %T; want %T", err, c.err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/mdm-code/termcols
 
 go 1.21
+
+require (
+	golang.org/x/sys v0.12.0 // indirect
+	golang.org/x/term v0.12.0 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,6 @@ module github.com/mdm-code/termcols
 
 go 1.21
 
-require (
-	golang.org/x/sys v0.12.0 // indirect
-	golang.org/x/term v0.12.0 // indirect
-)
+require golang.org/x/term v0.12.0
+
+require golang.org/x/sys v0.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
+golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.12.0 h1:/ZfYdc3zq+q02Rv9vGqTeSItdzZTSNDmfTi0mBAuidU=
+golang.org/x/term v0.12.0/go.mod h1:owVbMEjm3cBLCHdkQu9b1opXd4ETQWc3BhuQGKgXgvU=


### PR DESCRIPTION
- Add the Term package to the project
- Add colorize parameter to the pipe function
- Parametrize colorize depending if it is tty
- Adjust unit tests for the pipe function
- The term package is now used directly
- Include function documentation for pipe fn
